### PR TITLE
wrap reward function in useCallback to prevent rerendering components

### DIFF
--- a/src/hooks/useReward.ts
+++ b/src/hooks/useReward.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { confetti } from '../components/Confetti/Confetti';
 import { emoji } from '../components/Emoji/Emoji';
 import { balloons } from '../components/Balloons/Balloons';
@@ -12,45 +12,24 @@ export const useReward: UseRewardType = (id, type, config) => {
     setIsAnimating(false);
   };
 
-  let reward;
-  switch (type) {
-    case 'confetti': {
-      reward = () => {
-        const foundContainer = getContainerById(id);
-
-        if (!foundContainer) return;
-
-        setIsAnimating(true);
+  const reward = useCallback(() => {
+    const foundContainer = getContainerById(id);
+    if (!foundContainer) return;
+    setIsAnimating(true);
+    switch (type) {
+      case 'confetti':
         confetti(foundContainer, internalAnimatingCallback, config);
-      };
-      break;
-    }
-    case 'emoji': {
-      reward = () => {
-        const foundContainer = getContainerById(id);
-
-        if (!foundContainer) return;
-
-        setIsAnimating(true);
+        break;
+      case 'emoji':
         emoji(foundContainer, internalAnimatingCallback, config);
-      };
-      break;
-    }
-    case 'balloons': {
-      reward = () => {
-        const foundContainer = getContainerById(id);
-
-        if (!foundContainer) return;
-
-        setIsAnimating(true);
+        break;
+      case 'balloons':
         balloons(foundContainer, internalAnimatingCallback, config);
-      };
-      break;
-    }
-    default: {
-      reward = () =>
+        break;
+      default:
         console.error(`${type} is not a valid react-rewards type.`);
     }
-  }
+  }, [config, id, type]);
+
   return { reward, isAnimating };
 };


### PR DESCRIPTION
Thank you for this great library!
I used react-reward in my project and found a problem.

Currently useReward returns new reward function in every render.
It is better to wrap functions in useCallback.
It causes unnecessary re-rendering.

Simplest example.
In this code, reward function is called infinitely, because when isAnimating's state changes, reward function is called again and then isAnimating changes again. 
```
function App() {
  const { reward, isAnimating } = useReward("rewardId", "confetti");

  useEffect(() => {
    console.log("reward");
    reward();
  }, [reward]);
  return <div id="rewardId"></div>;
}
```