### PR TITLE
Add support for React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "prepublish": "yarn lint && rm -rf dist && NODE_ENV=production yarn build"
   },
   "peerDependencies": {
-    "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
-    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+    "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0  || ^19.0.0",
+    "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0  || ^19.0.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Updated `package.json` `peerDependencies` to support React 19. 

Tested on my project with Next.js 15, React 19 and found no issues.